### PR TITLE
feat: Add two missing stream event properties

### DIFF
--- a/schema/ext.keboola.stream.fileImport.json
+++ b/schema/ext.keboola.stream.fileImport.json
@@ -11,7 +11,13 @@
                 "projectId": {
                     "type": "integer"
                 },
+                "branchId": {
+                    "type": "integer"
+                },
                 "sourceId": {
+                    "type": "string"
+                },
+                "streamId": {
                     "type": "string"
                 },
                 "sinkId": {
@@ -58,7 +64,9 @@
             },
             "required": [
                 "projectId",
+                "branchId",
                 "sourceId",
+                "streamId",
                 "sinkId"
             ]
         }

--- a/schema/ext.keboola.stream.sliceUpload.json
+++ b/schema/ext.keboola.stream.sliceUpload.json
@@ -11,7 +11,13 @@
                 "projectId": {
                     "type": "integer"
                 },
+                "branchId": {
+                    "type": "integer"
+                },
                 "sourceId": {
+                    "type": "string"
+                },
+                "streamId": {
                     "type": "string"
                 },
                 "sinkId": {
@@ -58,7 +64,9 @@
             },
             "required": [
                 "projectId",
+                "branchId",
                 "sourceId",
+                "streamId",
                 "sinkId"
             ]
         }

--- a/schema/ext.keboola.stream.sourceCreate.json
+++ b/schema/ext.keboola.stream.sourceCreate.json
@@ -11,7 +11,13 @@
                 "projectId": {
                     "type": "integer"
                 },
+                "branchId": {
+                    "type": "integer"
+                },
                 "sourceId": {
+                    "type": "string"
+                },
+                "streamId": {
                     "type": "string"
                 },
                 "sourceName": {
@@ -23,7 +29,9 @@
             },
             "required": [
                 "projectId",
+                "branchId",
                 "sourceId",
+                "streamId",
                 "sourceName"
             ]
         }

--- a/schema/ext.keboola.stream.sourceDelete.json
+++ b/schema/ext.keboola.stream.sourceDelete.json
@@ -11,7 +11,13 @@
                 "projectId": {
                     "type": "integer"
                 },
+                "branchId": {
+                    "type": "integer"
+                },
                 "sourceId": {
+                    "type": "string"
+                },
+                "streamId": {
                     "type": "string"
                 },
                 "sourceName": {
@@ -23,7 +29,9 @@
             },
             "required": [
                 "projectId",
+                "branchId",
                 "sourceId",
+                "streamId",
                 "sourceName"
             ]
         }

--- a/schema/ext.keboola.stream.sourcePurge.json
+++ b/schema/ext.keboola.stream.sourcePurge.json
@@ -11,7 +11,13 @@
                 "projectId": {
                     "type": "integer"
                 },
+                "branchId": {
+                    "type": "integer"
+                },
                 "sourceId": {
+                    "type": "string"
+                },
+                "streamId": {
                     "type": "string"
                 },
                 "sourceName": {
@@ -23,7 +29,9 @@
             },
             "required": [
                 "projectId",
+                "branchId",
                 "sourceId",
+                "streamId",
                 "sourceName"
             ]
         }

--- a/tests/events/ext.keboola.stream.fileImport.json
+++ b/tests/events/ext.keboola.stream.fileImport.json
@@ -19,7 +19,9 @@
     },
     "results": {
         "projectId": 8763,
+        "branchId": 1,
         "sourceId": "my-source",
+        "streamId": "8763/1/my-source",
         "sinkId": "my-sink",
         "statistics": {
             "firstRecordAt": "2006-01-02T15:04:05.000Z",

--- a/tests/events/ext.keboola.stream.sliceUpload.json
+++ b/tests/events/ext.keboola.stream.sliceUpload.json
@@ -19,7 +19,9 @@
     },
     "results": {
         "projectId": 8763,
+        "branchId": 1,
         "sourceId": "my-source",
+        "streamId": "8763/1/my-source",
         "sinkId": "my-sink",
         "statistics": {
             "firstRecordAt": "2006-01-02T15:04:05.000Z",

--- a/tests/events/ext.keboola.stream.sourceCreate.json
+++ b/tests/events/ext.keboola.stream.sourceCreate.json
@@ -19,7 +19,9 @@
     },
     "results": {
         "projectId": 8763,
+        "branchId": 1,
         "sourceId": "my-source",
+        "streamId": "8763/1/my-source",
         "sourceName": "My stream v1",
         "error": ""
     },

--- a/tests/events/ext.keboola.stream.sourceDelete.json
+++ b/tests/events/ext.keboola.stream.sourceDelete.json
@@ -19,7 +19,9 @@
     },
     "results": {
         "projectId": 8763,
+        "branchId": 1,
         "sourceId": "my-source",
+        "streamId": "8763/1/my-source",
         "sourceName": "My stream v1",
         "error": ""
     },

--- a/tests/events/ext.keboola.stream.sourcePurge.json
+++ b/tests/events/ext.keboola.stream.sourcePurge.json
@@ -19,7 +19,9 @@
     },
     "results": {
         "projectId": 8763,
+        "branchId": 1,
         "sourceId": "my-source",
+        "streamId": "8763/1/my-source",
         "sourceName": "My stream v1",
         "error": ""
     },


### PR DESCRIPTION
When BranchId si peresent we have unique full key of stream. Adding streamId which is composite key of projectId branchId and sourceId.

Before asking for review make sure that:

- [x] you created a task for KBC team to update event-schema in Connection (validation in API endpoint) https://keboola.atlassian.net/browse/CT-1785
- [x] you notified everyone in #general that even schema is changing
