### PR TITLE
Allow also keboola.mcp-server-tool as component

### DIFF
--- a/schema/ext.keboola.mcp-server-tool.json
+++ b/schema/ext.keboola.mcp-server-tool.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "mcpServerContext": {
+      "type": "object",
+      "properties": {
+        "appEnv": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "userAgent": {
+          "type": "string"
+        },
+        "sessionId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "appEnv",
+        "version",
+        "userAgent",
+        "sessionId"
+      ]
+    },
+    "message": {
+      "type": "string"
+    },
+    "tool": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "arguments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": { "type": "string" },
+              "value": { "type": "string" }
+            },
+            "required": ["key", "value"]
+          }
+        }
+      },
+      "required": [
+        "name",
+        "arguments"
+      ]
+    }
+  },
+  "required": [
+    "mcpServerContext",
+    "message",
+    "tool"
+  ]
+}

--- a/tests/events/ext.keboola.mcp-server-tool.json
+++ b/tests/events/ext.keboola.mcp-server-tool.json
@@ -1,0 +1,47 @@
+{
+    "id": 1234567890,
+    "event": "ext.keboola.mcp-server-tool",
+    "component": "keboola.mcp-server-tool",
+    "message": "Test message for mcp-server",
+    "description": "",
+    "type": "info",
+    "runId": null,
+    "created": "2024-07-15T10:00:00+0200",
+    "configurationId": null,
+    "objectId": "",
+    "objectName": "",
+    "objectType": "",
+    "context": {
+        "remoteAddr": "127.0.0.1",
+        "httpReferer": null,
+        "httpUserAgent": "mcp-server-test-suite",
+        "apiVersion": "v1"
+    },
+    "mcpServerContext": {
+        "appEnv": "remote",
+        "version": "1.0.0",
+        "userAgent": "mcp-server-local",
+        "sessionId": "1234567890"
+    },
+    "tool": {
+        "name": "list-buckets",
+        "arguments": [
+            {
+                "key": "region",
+                "value": "eu-central-1"
+            },
+            {
+                "key": "branchId",
+                "value": "67890"
+            }
+        ]
+    },
+    "performance": {},
+    "token": {
+        "id": 98765,
+        "name": "test-user@keboola.com"
+    },
+    "idBranch": 67890,
+    "uri": "https://connection.keboola.com/v2/storage/events/1234567890",
+    "attachments": []
+}


### PR DESCRIPTION
Before asking for review make sure that:

- [ ] you created a task for KBC team to update event-schema in Connection (validation in API endpoint)
- [ ] you notified everyone in #general that even schema is changing

--

This is follow-up to: https://github.com/keboola/event-schema/pull/24

## Diff

### Schema

No change, just a copy

### Tests

```diff
--- tests/events/ext.keboola.mcp-server.tool.json	2025-09-02 22:28:36.645524604 +0200
+++ tests/events/ext.keboola.mcp-server-tool.json	2025-09-02 22:33:49.290221756 +0200
@@ -1,7 +1,7 @@
 {
     "id": 1234567890,
-    "event": "ext.keboola.mcp-server.tool",
-    "component": "keboola.mcp-server.tool",
+    "event": "ext.keboola.mcp-server-tool",
+    "component": "keboola.mcp-server-tool",
     "message": "Test message for mcp-server",
     "description": "",
     "type": "info",
```